### PR TITLE
fix: shebang change to bash

### DIFF
--- a/server.sh
+++ b/server.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 DOCKER_VERSION=`docker --version`


### PR DESCRIPTION
This scripts uses bash syntax (not sh). For most systems this will be irrelevant (since /bin/sh points to /bin/bash), but some systems (like for some users reporting issues on Discord/Self-hosting) are using native sh for /bin/sh.